### PR TITLE
brief simplify

### DIFF
--- a/src/C_proj_create.c
+++ b/src/C_proj_create.c
@@ -1,17 +1,13 @@
+
 #include <libproj.h>
-
-
-#include <R.h>
 #include <Rinternals.h>
 
 
 SEXP proj_create_text(SEXP crs_, SEXP format)
 {
   // unpack the input string
-  const char*  crs_in[] = {CHAR(STRING_ELT(crs_, 0))};
+  const char* crs_in = CHAR(STRING_ELT(crs_, 0));
 
-  //unused flag
-  int success = 0L;
   // output string assigned by proj_as_*() below
   const char  *outstring;
 
@@ -22,38 +18,34 @@ SEXP proj_create_text(SEXP crs_, SEXP format)
   // allocate the R output
   SEXP out = PROTECT(allocVector(STRSXP, 1));
 
-  PJ *pj;
-  if (!(pj =   proj_create(PJ_DEFAULT_CTX, *crs_in)))
-    error(proj_errno_string(proj_errno(0)));
+  PJ *pj = proj_create(PJ_DEFAULT_CTX, crs_in);
+  if (pj == NULL) {
+    Rf_error(
+      "Error creating transformation: %s",
+      proj_errno_string(proj_context_errno(PJ_DEFAULT_CTX))
+    );
+  }
+
   if (fmt == 0L) {
     // available types
     // PJ_WKT1_ESRI, PJ_WKT1_GDAL, PJ_WKT2_2015, PJ_WKT2_2015_SIMPLIFIED, PJ_WKT                                          2_2018, PJ_WKT2_2018_SIMPLIFIED;
-    outstring = proj_as_wkt(0, pj, PJ_WKT2_2018, NULL);
-
-    success = 1L;
+    outstring = proj_as_wkt(PJ_DEFAULT_CTX, pj, PJ_WKT2_2018, NULL);
+  } else if (fmt == 1L) {
+    // PJ_PROJ_4, PJ_PROJ_5;
+    outstring = proj_as_proj_string(PJ_DEFAULT_CTX, pj, PJ_PROJ_5, NULL);
+  } else {
+    proj_destroy(pj);
+    Rf_error("Can't create output projection string with type %d", fmt);
   }
-  if (fmt == 1L) {
-    //PJ_PROJ_4, PJ_PROJ_5;
-    outstring = proj_as_proj_string(0, pj, PJ_PROJ_5, NULL);
 
-    success = 1L;
-  }
-  //if (fmt ==  2L) {
-  // disabled for now 2010-02-26 (needs PROJ 6.2.0 and rwinlib is at 6.1.0)
-  //outstring = proj_as_projjson(0, pj, NULL);
-  //success = 1L;
-  //}
   // form output as a character vector *before* destroying proj object
   // The returned string is valid while the input obj parameter is valid, and
   // until a next call to proj_as_*() with the same input object.
   // https://proj.org/development/reference/functions.html#_CPPv411proj_as_wktP1                                          0PJ_CONTEXTPK2PJ11PJ_WKT_TYPEPPCKc
-
-  SET_STRING_ELT(out, 0, mkChar(outstring));
-
+  SET_STRING_ELT(out, 0, Rf_mkChar(outstring));
   proj_destroy(pj);
 
 
   UNPROTECT(1);
-
-  return(out);
+  return out;
 }


### PR DESCRIPTION
The big mistake was mine here in libproj!!! (And it's a very good thing you caught it). While debugging I made a few changes for you to take or leave.

I wonder if the name of this function should be more like `proj_translate()`, since it takes text and returns it in a specific format. A `proj_create()` function should probably return an external pointer to a `PJ*` (when I have a few moments I'll PR this so you can have a look at what I mean and take/leave as part of this package).