### PR TITLE
Coerce crs input as necessary

### DIFF
--- a/R/proj_crs_text.R
+++ b/R/proj_crs_text.R
@@ -30,7 +30,7 @@ proj_crs_text <- function(source, format = 0L) {
   stopifnot(is.character(source))
   stopifnot(length(source) == 1L)
   tst <- try(.Call("C_proj_crs_text",
-        crs_ = source,
+        crs_ = proj_add_type_crs_if_needed(source),
         format = as.integer(format),
         PACKAGE = "PROJ"), silent = TRUE)
   if (is.null(tst) || inherits(tst, "try-error")) return(NA_character_)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,14 @@
 paste_line <- function(...) {
   paste0(c(...), collapse = "\n")
 }
+
+# ported from https://github.com/OSGeo/PROJ/blob/af8a4edc4e0ce9e56098439181d6f717bcadd5a6/src/4D_api.cpp#L1173-L1181
+proj_add_type_crs_if_needed <- function(crs) {
+  if ((startsWith(crs, "proj=") || startsWith(crs, "+proj=") ||
+      startsWith(crs, "+init=") || startsWith(crs, "+title=")) &&
+      !grepl("type=crs", crs, fixed = TRUE)) {
+    paste(crs, "+type=crs")
+  } else {
+    crs
+  }
+}

--- a/R/wk-trans.R
+++ b/R/wk-trans.R
@@ -21,8 +21,8 @@
 #'
 #' @export
 proj_trans_create <- function(source_crs, target_crs, use_z = NA, use_m = NA) {
-  source_crs <- wk::wk_crs_proj_definition(source_crs)
-  target_crs <- wk::wk_crs_proj_definition(target_crs)
+  source_crs <- proj_add_type_crs_if_needed(wk::wk_crs_proj_definition(source_crs))
+  target_crs <- proj_add_type_crs_if_needed(wk::wk_crs_proj_definition(target_crs))
 
   if (is.na(source_crs) || nchar(source_crs) == 0) stop("`source_crs` is invalid")
   if (is.na(target_crs) || nchar(target_crs) == 0) stop("`target_crs` is invalid")
@@ -50,7 +50,7 @@ wk_trans_inverse.proj_trans <- function(trans, ...) {
 #' @export
 print.proj_trans <- function(x, ...) {
   info <- proj_trans_info(x)
-  
+
   # FIXME: cleanup repetitive code
   lines <- paste_line(
     sprintf("<proj_trans at %s>", .Call(C_xptr_addr, x)),
@@ -76,7 +76,7 @@ print.proj_trans <- function(x, ...) {
     sprintf("    name: %s", info$target_crs$area_of_use$name),
     sprintf("    bounds: %s", info$target_crs$area_of_use$bounds)
   )
-  
+
   cat(lines, sep = "\n")
 
   invisible(x)

--- a/tests/testthat/test-wk-trans.R
+++ b/tests/testthat/test-wk-trans.R
@@ -117,3 +117,16 @@ test_that("inverse(proj_trans) print method works", {
   expect_match(str, "<proj_trans at .*>")
   expect_match(str, "source_crs.*EPSG:3112.*target_crs.*EPSG:4283")
 })
+
+test_that("proj_trans_create() adds crs type if needed", {
+  expect_no_error(proj_trans_create("+proj=longlat +datum=WGS84 +no_defs +type=crs", "+proj=longlat +datum=WGS84 +no_defs"))
+
+  info <- proj_trans_info(
+    proj_trans_create(
+      "+proj=longlat +datum=WGS84 +no_defs +type=crs",
+      "+proj=longlat +datum=WGS84 +no_defs"
+    )
+  )
+
+  expect_identical(info$source_crs, info$target_crs)
+})


### PR DESCRIPTION
Reverts strict crs type requirement for proj strings.

Fixes #52 